### PR TITLE
Return trajectory-provider object in loading methods

### DIFF
--- a/src/viewer/helpers/model.ts
+++ b/src/viewer/helpers/model.ts
@@ -14,25 +14,33 @@ import { BuiltInTrajectoryFormat } from 'molstar/lib/mol-plugin-state/formats/tr
 import { TrajectoryHierarchyPresetProvider } from 'molstar/lib/mol-plugin-state/builder/structure/hierarchy-preset';
 
 export class ModelLoader {
-    async load<P = {}>(load: LoadParams, props?: PresetProps, matrix?: Mat4, reprProvider?: TrajectoryHierarchyPresetProvider<P>, params?: P) {
+    async load<P = {}, S={}>(load: LoadParams, props?: PresetProps, matrix?: Mat4, reprProvider?: TrajectoryHierarchyPresetProvider<P, S>, params?: P) {
         const { fileOrUrl, format, isBinary } = load;
 
         const data = fileOrUrl instanceof File
             ? (await this.plugin.builders.data.readFile({ file: Asset.File(fileOrUrl), isBinary })).data
             : await this.plugin.builders.data.download({ url: fileOrUrl, isBinary });
-        await this.handleTrajectory<P>(data, format, props, matrix, reprProvider, params);
+
+        return await this.handleTrajectory<P, S>(data, format, props, matrix, reprProvider, params);
     }
 
-    async parse<P = {}>(parse: ParseParams, props?: PresetProps & { dataLabel?: string }, matrix?: Mat4, reprProvider?: TrajectoryHierarchyPresetProvider<P>, params?: P) {
+    async parse<P = {}, S={}>(parse: ParseParams, props?: PresetProps & { dataLabel?: string }, matrix?: Mat4, reprProvider?: TrajectoryHierarchyPresetProvider<P, S>, params?: P) {
         const { data, format } = parse;
         const _data = await this.plugin.builders.data.rawData({ data, label: props?.dataLabel });
-        await this.handleTrajectory(_data, format, props, matrix, reprProvider, params);
+        return await this.handleTrajectory(_data, format, props, matrix, reprProvider, params);
     }
 
-    private async handleTrajectory<P = {}>(data: any, format: BuiltInTrajectoryFormat, props?: PresetProps, matrix?: Mat4, reprProvider?: TrajectoryHierarchyPresetProvider<P>, params?: P) {
+    private async handleTrajectory<P = {}, S = {}>(
+        data: any,
+        format: BuiltInTrajectoryFormat,
+        props?: PresetProps,
+        matrix?: Mat4,
+        reprProvider?: TrajectoryHierarchyPresetProvider<P, S>,
+        params?: P
+    ): Promise<S|ReturnType<typeof RcsbPreset.apply>|undefined> {
         const trajectory = await this.plugin.builders.structure.parseTrajectory(data, format);
         if (reprProvider) {
-            await this.plugin.builders.structure.hierarchy.applyPreset(trajectory, reprProvider, { ...params } as P);
+            return this.plugin.builders.structure.hierarchy.applyPreset(trajectory, reprProvider, params);
         } else {
             const selector = await this.plugin.builders.structure.hierarchy.applyPreset(trajectory, RcsbPreset, {
                 preset: props || { kind: 'standard', assemblyId: '' }
@@ -49,6 +57,7 @@ export class ModelLoader {
                     .insert(StateTransforms.Model.TransformStructureConformation, params);
                 await this.plugin.runTask(this.plugin.state.data.updateTree(b));
             }
+            return selector;
         }
 
     }

--- a/src/viewer/index.ts
+++ b/src/viewer/index.ts
@@ -277,26 +277,27 @@ export class Viewer {
         return PluginCommands.State.RemoveObject(this._plugin, { state, ref: state.tree.root.ref });
     }
 
-    async loadPdbId<P>(pdbId: string, config?: { props?: PresetProps; matrix?: Mat4; reprProvider?: TrajectoryHierarchyPresetProvider, params?: P }) {
+    async loadPdbId<P, S>(pdbId: string, config?: { props?: PresetProps; matrix?: Mat4; reprProvider?: TrajectoryHierarchyPresetProvider<P, S>, params?: P }) {
         for (const provider of this.modelUrlProviders) {
             try {
                 const p = provider(pdbId);
-                await this.customState.modelLoader.load({ fileOrUrl: p.url, format: p.format, isBinary: p.isBinary }, config?.props, config?.matrix, config?.reprProvider, config?.params);
-                break;
+                return await this.customState.modelLoader.load<P, S>({ fileOrUrl: p.url, format: p.format, isBinary: p.isBinary }, config?.props, config?.matrix, config?.reprProvider, config?.params);
             } catch (e) {
                 console.warn(`loading '${pdbId}' failed with '${e}', trying next model-loader-provider`);
             }
         }
     }
 
-    async loadPdbIds<P>(args: { pdbId: string, config?: {props?: PresetProps; matrix?: Mat4; reprProvider?: TrajectoryHierarchyPresetProvider, params?: P} }[]) {
+    async loadPdbIds<P, S>(args: { pdbId: string, config?: {props?: PresetProps; matrix?: Mat4; reprProvider?: TrajectoryHierarchyPresetProvider<P, S>, params?: P} }[]) {
+        const out = [];
         for (const { pdbId, config } of args) {
-            await this.loadPdbId(pdbId, config);
+            out.push(await this.loadPdbId(pdbId, config));
         }
         this.resetCamera(0);
+        return out;
     }
 
-    loadStructureFromUrl<P>(url: string, format: BuiltInTrajectoryFormat, isBinary: boolean, config?: {props?: PresetProps; matrix?: Mat4; reprProvider?: TrajectoryHierarchyPresetProvider, params?: P}) {
+    loadStructureFromUrl<P, S>(url: string, format: BuiltInTrajectoryFormat, isBinary: boolean, config?: {props?: PresetProps; matrix?: Mat4; reprProvider?: TrajectoryHierarchyPresetProvider<P, S>, params?: P}) {
         return this.customState.modelLoader.load({ fileOrUrl: url, format, isBinary }, config?.props, config?.matrix, config?.reprProvider, config?.params);
     }
 
@@ -304,7 +305,7 @@ export class Viewer {
         return PluginCommands.State.Snapshots.OpenUrl(this._plugin, { url, type });
     }
 
-    loadStructureFromData<P>(data: string | number[], format: BuiltInTrajectoryFormat, isBinary: boolean, config?: {props?: PresetProps & { dataLabel?: string }; matrix?: Mat4; reprProvider?: TrajectoryHierarchyPresetProvider, params?: P}) {
+    loadStructureFromData<P, S>(data: string | number[], format: BuiltInTrajectoryFormat, isBinary: boolean, config?: {props?: PresetProps & { dataLabel?: string }; matrix?: Mat4; reprProvider?: TrajectoryHierarchyPresetProvider<P, S>, params?: P}) {
         return this.customState.modelLoader.parse({ data, format, isBinary }, config?.props, config?.matrix, config?.reprProvider, config?.params);
     }
 


### PR DESCRIPTION
Return the object created in `RcsbPreset.apply`  or the trajectory-provider object when provided by the user in the different loading methods: `loadPdbId`, `loadPdbIds`, `loadStructureFromUrl`